### PR TITLE
Fix [sc-8784]: Fix sitemap connector

### DIFF
--- a/server/src/logic/connector/infrastructure/connectors/sitemap.connector.ts
+++ b/server/src/logic/connector/infrastructure/connectors/sitemap.connector.ts
@@ -1,7 +1,7 @@
 import { from, map, Observable, of, switchMap } from 'rxjs';
 import { ConnectorParameters, FileStatus, IConnector, Link, SearchResults, SyncItem } from '../../domain/connector';
 import { SourceConnectorDefinition } from '../factory';
-import cheerio from 'cheerio';
+import * as cheerio from 'cheerio';
 
 interface SiteMapModel {
   loc: string;
@@ -10,7 +10,7 @@ interface SiteMapModel {
 
 async function fetchSitemap(url: string): Promise<string> {
   const response = await fetch(url);
-  // todo: control whether it is zipped or plain
+  // TODO: control whether it is zipped or plain
   return response.text();
 }
 
@@ -53,11 +53,8 @@ class SitemapImpl implements IConnector {
     this.params = params;
   }
 
-  areParametersValid(params: ConnectorParameters) {
-    if (!params?.sitemap) {
-      return false;
-    }
-    return true;
+  areParametersValid(params: ConnectorParameters): boolean {
+    return !!params?.sitemap;
   }
 
   getParameters(): ConnectorParameters {

--- a/server/src/logic/sync/domain/sync.entity.ts
+++ b/server/src/logic/sync/domain/sync.entity.ts
@@ -105,14 +105,14 @@ export class SyncEntity {
     const foldersToSyncUpdated: SyncItem[] = (this.foldersToSync ?? []).filter(
       (folder) => folder.status === FileStatus.UPLOADED,
     );
-    const getFilesFoldersUpdated = this.sourceConnector!.getLastModified(
+    const getFilesFoldersUpdated = foldersToSyncUpdated.length > 0 ? this.sourceConnector!.getLastModified(
       this.lastSyncGMT || '2000-01-01T00:00:00.000Z',
       foldersToSyncUpdated,
-    );
-    const getFilesFolderPending = this.sourceConnector!.getFilesFromFolders(foldersToSyncPending);
+    ) : of({items: []});
+
+    const getFilesFolderPending = foldersToSyncPending.length > 0 ? this.sourceConnector!.getFilesFromFolders(foldersToSyncPending) : of({items: []});
     return forkJoin([getFilesFoldersUpdated, getFilesFolderPending]).pipe(
-      map((results) => {
-        const [updated, pending] = results;
+      map(([updated, pending]) => {
         return { success: true, results: [...updated.items, ...pending.items] };
       }),
       catchError((err) => {

--- a/server/src/logic/sync/domain/sync.entity.ts
+++ b/server/src/logic/sync/domain/sync.entity.ts
@@ -105,12 +105,15 @@ export class SyncEntity {
     const foldersToSyncUpdated: SyncItem[] = (this.foldersToSync ?? []).filter(
       (folder) => folder.status === FileStatus.UPLOADED,
     );
-    const getFilesFoldersUpdated = foldersToSyncUpdated.length > 0 ? this.sourceConnector!.getLastModified(
-      this.lastSyncGMT || '2000-01-01T00:00:00.000Z',
-      foldersToSyncUpdated,
-    ) : of({items: []});
+    const getFilesFoldersUpdated =
+      foldersToSyncUpdated.length > 0
+        ? this.sourceConnector!.getLastModified(this.lastSyncGMT || '2000-01-01T00:00:00.000Z', foldersToSyncUpdated)
+        : of({ items: [] });
 
-    const getFilesFolderPending = foldersToSyncPending.length > 0 ? this.sourceConnector!.getFilesFromFolders(foldersToSyncPending) : of({items: []});
+    const getFilesFolderPending =
+      foldersToSyncPending.length > 0
+        ? this.sourceConnector!.getFilesFromFolders(foldersToSyncPending)
+        : of({ items: [] });
     return forkJoin([getFilesFoldersUpdated, getFilesFolderPending]).pipe(
       map(([updated, pending]) => {
         return { success: true, results: [...updated.items, ...pending.items] };


### PR DESCRIPTION
Fix `sync.entity` `getLastModified` function to call the method to get files from the connector only if the folders to sync is not empty. This is for preventing syncs with static folders like sitemap to upload their content several times on a same sync, and to prevent uploading the files on each synchronization.