### PR TITLE
Pin SHA1 GHA

### DIFF
--- a/.github/workflows/bd_sca_scanner.yml
+++ b/.github/workflows/bd_sca_scanner.yml
@@ -21,7 +21,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Calculate detect-args for BD SCA Scan
         id: calculate-detect-args
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Black Duck SCA PR Scan
         id: blackduck-pr-scan
-        uses: blackduck-inc/black-duck-security-scan@v2
+        uses: blackduck-inc/black-duck-security-scan@659a0742e793a093377fab3117b0d90f23b04bfa # v2.9.0
         env:
           DETECT_PROJECT_NAME: nuclia-sync-agent
           DETECT_PROJECT_GROUP_NAME: Nuclia

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
 
@@ -45,7 +45,7 @@ jobs:
         run: node utils/get-version.js >> $GITHUB_ENV
 
       - name: Tag if new version
-        uses: pkgdeps/git-tag-action@v2.0.5
+        uses: pkgdeps/git-tag-action@291b77f84cdb3f0a3e5491879cfdcd172d5777e0 # v2.0.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_repo: ${{ github.repository }}
@@ -62,11 +62,11 @@ jobs:
       release-tag: ${{ steps.release.outputs.release_tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Release
-        uses: justincy/github-action-npm-release@2.0.2
+        uses: justincy/github-action-npm-release@f6afd60cbb595a76ecae037ad006671636d321f5 # 2.0.2
         id: release
 
   build_macos_linux:
@@ -78,14 +78,14 @@ jobs:
         os: [macos-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         if: startsWith(matrix.os, 'macos')
         with:
           python-version: '3.11'
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
 
@@ -129,7 +129,7 @@ jobs:
         run: npm run make
 
       - name: Release MacOSX installer
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         if: startsWith(matrix.os, 'macos')
         with:
           tag_name: ${{ needs.pre-release.outputs.release-tag }}
@@ -137,7 +137,7 @@ jobs:
             electron-app/out/make/*.dmg
 
       - name: Release Linux installer
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         if: startsWith(matrix.os, 'ubuntu')
         with:
           tag_name: ${{ needs.pre-release.outputs.release-tag }}
@@ -151,14 +151,14 @@ jobs:
     steps:
       - name: Generate a token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.GHAPP_ID_NUCLIABOT }}
           private-key: ${{ secrets.PK_GHAPP_NUCLIABOT_ORG }}
           owner: nuclia
 
       - name: Trigger Windows Release
-        uses: the-actions-org/workflow-dispatch@v4
+        uses: the-actions-org/workflow-dispatch@3133c5d135c7dbe4be4f9793872b6ef331b53bc7 # v4.0.0
         id: invoke-windows-release
         with:
           workflow: 'Sync Agent Windows Release'

--- a/.github/workflows/polaris.yaml
+++ b/.github/workflows/polaris.yaml
@@ -16,13 +16,13 @@ jobs:
       checks: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
       - name: Run Polaris PR Scan
         id: polaris-pr-scan
-        uses: blackduck-inc/black-duck-security-scan@v2
+        uses: blackduck-inc/black-duck-security-scan@659a0742e793a093377fab3117b0d90f23b04bfa # v2.9.0
         with:
             polaris_server_url: 'https://polaris.blackduck.com'
             polaris_access_token: ${{ secrets.POLARIS_ACCESS_TOKEN }}

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
       - name: install dependencies electron-app

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: nuclia-base
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       
       - name: TruffleHog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab # v3.95.3
         with:
           extra_args: --results=verified,unknown


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use pinned action versions with explicit commit SHAs instead of floating tags or branches. This improves security and reliability by ensuring that workflows always use a known, immutable version of each action.

The most important changes are:

**Security and Stability Improvements:**

* All GitHub Actions in workflow files such as `.github/workflows/build.yml`, `.github/workflows/test.yml`, `.github/workflows/publish-server.yml`, `.github/workflows/bd_sca_scanner.yml`, `.github/workflows/polaris.yaml`, and `.github/workflows/trufflehog.yaml` are now referenced by specific commit SHAs instead of tags or branch names, reducing the risk of supply chain attacks and unexpected changes. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11-R14) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L48-R48) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L65-R69) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L81-R88) [[5]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L132-R140) [[6]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L154-R161) [[7]](diffhunk://#diff-951c680af92aad1d64ab1263be932f6f1c03ae26d892c237dc4bac860a0c93dcL17-R21) [[8]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L14-R17) [[9]](diffhunk://#diff-a9a38e1dee588f074af68b6e39680d6b3aeefee445ab75a1039de4c0fc3c576aL24-R24) [[10]](diffhunk://#diff-a9a38e1dee588f074af68b6e39680d6b3aeefee445ab75a1039de4c0fc3c576aL37-R37) [[11]](diffhunk://#diff-f265d1510b4f87f60f844133dfc76b27fad500ef14199f1fd9747cfe21cdbfbbL19-R25) [[12]](diffhunk://#diff-0226146bc805a4132588ddc39ae916b6f2be619f3b0765d40be3034ec5b87c3bL13-R18)

**Workflow Consistency:**

* Updated all uses of `actions/checkout`, `actions/setup-node`, `actions/setup-python`, `blackduck-inc/black-duck-security-scan`, `softprops/action-gh-release`, `justincy/github-action-npm-release`, `pkgdeps/git-tag-action`, `the-actions-org/workflow-dispatch`, `actions/create-github-app-token`, and `trufflesecurity/trufflehog` to reference the latest known good SHAs for their respective versions. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11-R14) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L48-R48) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L65-R69) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L81-R88) [[5]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L132-R140) [[6]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L154-R161) [[7]](diffhunk://#diff-951c680af92aad1d64ab1263be932f6f1c03ae26d892c237dc4bac860a0c93dcL17-R21) [[8]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L14-R17) [[9]](diffhunk://#diff-a9a38e1dee588f074af68b6e39680d6b3aeefee445ab75a1039de4c0fc3c576aL24-R24) [[10]](diffhunk://#diff-a9a38e1dee588f074af68b6e39680d6b3aeefee445ab75a1039de4c0fc3c576aL37-R37) [[11]](diffhunk://#diff-f265d1510b4f87f60f844133dfc76b27fad500ef14199f1fd9747cfe21cdbfbbL19-R25) [[12]](diffhunk://#diff-0226146bc805a4132588ddc39ae916b6f2be619f3b0765d40be3034ec5b87c3bL13-R18)

These changes collectively ensure that CI/CD workflows are more secure, predictable, and maintainable.