### PR TITLE
Bump GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -51,18 +51,18 @@ jobs:
           github_repo: ${{ github.repository }}
           version: ${{ env.PACKAGE_VERSION }}
           git_commit_sha: ${{ github.sha }}
-          git_tag_prefix: 'v'
+          git_tag_prefix: "v"
 
   pre-release:
-    name: 'Pre Release'
+    name: "Pre Release"
     needs: build
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     outputs:
       release-desktop: ${{ steps.release.outputs.released }}
       release-tag: ${{ steps.release.outputs.release_tag }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Release
@@ -78,13 +78,13 @@ jobs:
         os: [macos-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         if: startsWith(matrix.os, 'macos')
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
@@ -122,7 +122,7 @@ jobs:
       - name: make
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLE_API_KEY: '~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8'
+          APPLE_API_KEY: "~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8"
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           CI: false
@@ -161,7 +161,7 @@ jobs:
         uses: the-actions-org/workflow-dispatch@3133c5d135c7dbe4be4f9793872b6ef331b53bc7 # v4.0.0
         id: invoke-windows-release
         with:
-          workflow: 'Sync Agent Windows Release'
+          workflow: "Sync Agent Windows Release"
           repo: nuclia/core-apps
           ref: main
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Bump NPM version
         run: |-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest version of the `actions/checkout` action and standardizes the use of double quotes for string values throughout the workflow YAML files. These changes improve security, maintainability, and consistency in CI/CD configuration.

**Dependency updates:**

* Updated all instances of `actions/checkout` from version `v4.3.1` to `v6.0.3` in `.github/workflows/build.yml`, `.github/workflows/publish-server.yml`, and `.github/workflows/test.yml` for improved security and features. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11-R11) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L54-R65) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L81-R87) [[4]](diffhunk://#diff-951c680af92aad1d64ab1263be932f6f1c03ae26d892c237dc4bac860a0c93dcL17-R24) [[5]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L14-R14)

**Formatting and consistency:**

* Standardized string values to use double quotes instead of single quotes for parameters and environment variables in workflow files (e.g., `git_tag_prefix`, `python-version`, `APPLE_API_KEY`, `workflow`, and `registry-url`). [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L54-R65) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L81-R87) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L125-R125) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L164-R164) [[5]](diffhunk://#diff-951c680af92aad1d64ab1263be932f6f1c03ae26d892c237dc4bac860a0c93dcL17-R24)

No functional logic changes were made to the build, test, or publish processes.